### PR TITLE
Initial implementation & example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/examples/classification/simple_prediction.ts
+++ b/examples/classification/simple_prediction.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import OpenAI from "openai";
+import { MODES, patch } from "instructor";
+
+const SimplePredictionSchema = z.object({
+  class_label: z.enum(["spam", "not_spam"]),
+});
+
+type SimplePrediction = z.infer<typeof SimplePredictionSchema>;
+
+const client = patch({
+  client: new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY
+  }),
+  mode: MODES.TOOLS,
+});
+
+const classify = async (data: string): Promise<SimplePrediction> => {
+  return await client.chat.completions.create({
+    messages: [
+      {
+        role: "user",
+        content: `Classify the following text: ${data}`,
+      }
+    ],
+    model: "gpt-4-0613",
+    responseModel: SimplePredictionSchema,
+  }) 
+};
+
+const run = async () => {
+  const prediction = await classify("Hello there I'm a nigerian prince and I want to give you money");
+  if (prediction.class_label != "spam") {
+    throw new Error("Expected spam");
+  }
+
+  console.log(`Classified as: ${prediction.class_label}`);
+};
+
+run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "openai": "^4.24.1",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "devDependencies": {
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@types/node": {
@@ -260,6 +264,19 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -293,6 +310,14 @@
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.22.3.tgz",
+      "integrity": "sha512-9isG8SqRe07p+Aio2ruBZmLm2Q6Sq4EqmXOiNpDxp+7f0LV6Q/LX65fs5Nn+FV/CzfF3NLBoksXbS2jNYIfpKw==",
+      "peerDependencies": {
+        "zod": "^3.22.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "instructor",
   "version": "0.0.1",
   "description": "structured outputs for llms",
-  "main": "index.js",
+  "main": "./dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "clean": "rm -rf ./dist/*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc",
+    "build": "tsc && npm link instructor",
     "build:watch": "tsc --watch",
     "clean": "rm -rf ./dist/*"
   },
@@ -27,6 +27,10 @@
   "homepage": "https://github.com/jxnl/instructor-js#readme",
   "dependencies": {
     "openai": "^4.24.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.3"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,120 @@
+import OpenAI from 'openai';
+import { APIPromise } from 'openai/core';
+import { ChatCompletion } from 'openai/resources';
+import { Chat } from 'openai/resources/chat/chat';
+import { ZodSchema } from 'zod';
+import zodToJsonSchema from 'zod-to-json-schema';
+
+export enum MODES {
+  TOOLS = 'tools',
+  // ... other modes in the future
+}
+
+export interface PatchConfig {
+  client: OpenAI;
+  mode?: MODES;
+}
+
+export interface ChatCompletionsCreateConfig<T> extends OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming {
+  responseModel: ZodSchema<T>;
+  maxRetries?: number;
+}
+
+export interface PatchedChat {
+  chat: {
+    completions: {
+      create<T>(config: ChatCompletionsCreateConfig<T>): Promise<T>;
+    };
+  };
+}
+
+export type PatchedClient = OpenAI & PatchedChat;
+
+type OpenAICompletionBody = OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming;
+
+// There's probably a nicer way to do this, but zod doesn't give us a schema name
+const DEFAULT_OPENAI_TOOL_NAME = "call_this_function";
+
+function patchCreateChatCompletion(chat: Chat) {
+  const originalFn = chat.completions.create;
+
+  const completionFn = async <T>({responseModel, maxRetries, ...rest}: ChatCompletionsCreateConfig<T>, options?: any) => {
+    if (!maxRetries) {
+      maxRetries = 0;
+    }
+
+    const openaiBody: OpenAICompletionBody = rest;
+
+    openaiBody.tool_choice = {
+      type: "function",
+      function: {
+        name: DEFAULT_OPENAI_TOOL_NAME,
+      }
+    };
+
+    openaiBody.tools = [{
+      type: "function",
+      function: {
+        name: DEFAULT_OPENAI_TOOL_NAME,
+        parameters: zodToJsonSchema(responseModel),
+      }
+    }]
+
+    let retries = 0;
+    let response: ChatCompletion | undefined = undefined;
+
+    while (retries <= maxRetries) {
+      try {
+        // We need to provide the 'this' manually so it's not null
+        response = await originalFn.call(chat.completions, openaiBody, options) as ChatCompletion; // we have to force the type because we're using .call
+
+        // const resp = await fn(openaiBody, options);
+
+        if (!response.choices?.[0].message?.tool_calls) {
+          throw new Error("Invalid response format");
+        }
+
+        const responseObject = JSON.parse(response.choices[0].message.tool_calls[0].function.arguments);
+        responseModel.parse(responseObject);
+
+        return responseObject;
+      } catch (e) {
+        retries += 1
+        if (retries > maxRetries) {
+          throw e;          
+        }
+        if (response) {
+          openaiBody.messages.push(response.choices[0].message);
+          openaiBody.messages.push({
+            role: "user",
+            content: `Recall the function correctly, fix the errors, exceptions found\n${e}`,
+          })
+        }
+      }
+    }
+  }
+
+  // We can have correct types here with a bit of wrangling
+  chat.completions.create = completionFn as any;
+};
+
+export function patch(config: PatchConfig): PatchedClient {
+  if (!config.client) {
+    throw new Error("Provide an OpenAI client");
+  }
+
+  if (!config.mode) {
+    config.mode = MODES.TOOLS;
+  }
+
+  switch (config.mode) {
+    case MODES.TOOLS:
+      patchCreateChatCompletion(config.client.chat);
+      break;      
+
+    default:
+      throw new Error("Unsupported mode: " + config.mode);
+  }
+
+  return config.client;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2018",                          // Specify ECMAScript target version
+    "module": "commonjs",                        // Specify module code generation
+    "lib": ["ES2018"],                           // Specify a list of library files to be included in the compilation
+    "declaration": true,                         // Generates corresponding '.d.ts' file for each output '.js' file
+    "outDir": "./dist",                          // Redirect output structure to the directory
+    "rootDir": "./src",                          // Specify the root directory of input files
+
+    /* Strict Type-Checking Options */
+    "strict": true,                              // Enable all strict type-checking options
+
+    /* Additional Checks */
+    "noImplicitAny": true,                       // Raise error on expressions and declarations with an implied 'any' type
+    "strictNullChecks": true,                    // Enable strict null checks
+    "strictFunctionTypes": true,                 // Enable strict checking of function types
+    "strictBindCallApply": true,                 // Enable strict 'bind', 'call', and 'apply' methods on functions
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",                  // Resolve modules using Node.js style
+    "baseUrl": "./",                             // Base directory to resolve non-relative module names
+    "esModuleInterop": true,                     // Enables emit interoperability between CommonJS and ES Modules
+
+    /* Advanced Options */
+    "skipLibCheck": true,                        // Skip type checking of all declaration files (*.d.ts)
+    "forceConsistentCasingInFileNames": true     // Disallow inconsistently-cased references to the same file
+  },
+  "include": [
+    "src/**/*"                                   // Include all files in the src directory
+  ],
+  "exclude": [
+    "node_modules",                              // Exclude the node_modules directory
+    "**/*.spec.ts"                               // Exclude test files
+  ]
+}
+


### PR DESCRIPTION
Implements the basics of instructor-js:

- Use zod to specify a schema
- Patch the chat completion function while leaving all other functions in the client alone
- Retry if parsing or validation of the response type fails
- TS type hints at the api boundary (there's a couple `any`s we can clean up in the implementation itself)

There's still lots to be done. At a glance:

- It's all one file
- Instructor has logging throughout which this doesn't
- I'm sure this has many bugs I've straight-up missed
- More thorough testing & CI
- Consistent style/linting enforced through prettier/eslint