### PR TITLE
Clean up build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "instructor-js",
   "version": "0.0.1",
   "description": "structured outputs for llms",
-  "main": "./dist/instructor.js",
-  "module": "./dist/instructor.mjs",
-  "types": "./dist/instructor.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/instructor.mjs",
-      "require": "./dist/instructor.js"
-    }
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+      }
   },
   "publishConfig": {
     "access": "public"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * as Instructor from "./instructor"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
`bun run build` didn't work on macOS due to weird TS error. Also, changed package.json so we can export things other than just the default wrapper.